### PR TITLE
properly use battery.state_of_charge for capacity

### DIFF
--- a/src/app/ui/painter.rs
+++ b/src/app/ui/painter.rs
@@ -281,6 +281,11 @@ impl<'i> Painter<'i> {
         );
         let capacity = &format!(
             "{:.2} {}",
+            battery.state_of_charge().get::<percent>(),
+            percent::abbreviation()
+        );
+        let health = &format!(
+            "{:.2} {}",
             battery.state_of_health().get::<percent>(),
             percent::abbreviation()
         );
@@ -330,6 +335,7 @@ impl<'i> Painter<'i> {
             [consumption_label, consumption],
             ["Voltage", voltage],
             ["Capacity", capacity],
+            ["Health", health],
             ["Current", current],
             ["Last full", last_full],
             ["Full design", full_design],


### PR DESCRIPTION
This was mistakenly showing battery.state_of_health() as capacity. Instead, use state_of_charge() as capacity, and add a new "Health" value to the output.

This was an issue in the original battop project, but your fork seems to be the only active version, so I'm looking to switch to batmon instead.

Relevant docs on the battery crate: 
 - https://docs.rs/battery/latest/battery/struct.Battery.html#method.state_of_charge
 - https://docs.rs/battery/latest/battery/struct.Battery.html#method.state_of_health