### PR TITLE
Fix usage of crane.mkLib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,7 @@
         };
 
         lib = nixpkgs.lib;
-        craneLib = crane.lib.${system};
-
+        craneLib = crane.mkLib pkgs;
         src = lib.cleanSourceWith {
           src = craneLib.path ./.;
         };


### PR DESCRIPTION
On master, `nix build` does not work:

```
error: attribute 'lib' missing
       at /nix/store/mxlabdlvkxi947bsppzdqyg4lqsvlc4c-source/flake.nix:36:20:
           35|         lib = nixpkgs.lib;
           36|         craneLib = crane.lib.${system};
             |                    ^
           37|
```

I found the correct usage from here: https://github.com/ipetkov/crane/blob/70947c1908108c0c551ddfd73d4f750ff2ea67cd/examples/quick-start-simple/flake.nix#L17